### PR TITLE
Fix syntax definition syntax and references

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -19,16 +19,16 @@ This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]]
 ## Definition
 
 ```ABNF
-list        = list-member 0*179( OWS "," OWS list-member )
-list-member = key OWS "=" OWS value *( OWS ";" OWS property )
-property    = key OWS "=" OWS value
-property    = key OWS
-key         = token ; as defined in RFC 2616, Section 2.2
-value       = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
-              ; US-ASCII characters excluding CTLs,
-              ; whitespace, DQUOTE, comma, semicolon,
-              ; and backslash
-OWS         = *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
+list        =  list-member 0*179( OWS "," OWS list-member )
+list-member =  key OWS "=" OWS value *( OWS ";" OWS property )
+property    =  key OWS "=" OWS value
+property    =/ key OWS
+key         =  token ; as defined in RFC 2616, Section 2.2
+value       =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+               ; US-ASCII characters excluding CTLs,
+               ; whitespace, DQUOTE, comma, semicolon,
+               ; and backslash
+OWS         =  *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
 ```
 
 ## Limits

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -18,17 +18,17 @@ This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]]
 
 ## Definition
 
-```
+```abnf
 list        = list-member 0*179( OWS "," OWS list-member )
 list-member = key OWS "=" OWS value *( OWS ";" OWS property )
 property    = key OWS "=" OWS value
 property    = key OWS
-key         = <token, defined in [[RFC2616], Section 2.2](https://tools.ietf.org/html/rfc2616#section-2.2)>
+key         = <token, as defined in RFC 2616, Section 2.2>
 value       = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
               ; US-ASCII characters excluding CTLs,
               ; whitespace, DQUOTE, comma, semicolon,
               ; and backslash
-OWS         = <Optional white space, as defined in [[RFC7230], Section 3.2.3.](https://tools.ietf.org/html/rfc7230#section-3.2.3)>
+OWS         = <optional white space, as defined in RFC 7230, Section 3.2.3>
 ```
 
 ## Limits

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -18,17 +18,17 @@ This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]]
 
 ## Definition
 
-```text
+```ABNF
 list        = list-member 0*179( OWS "," OWS list-member )
 list-member = key OWS "=" OWS value *( OWS ";" OWS property )
 property    = key OWS "=" OWS value
 property    = key OWS
-key         = <token, as defined in RFC 2616, Section 2.2>
+key         = token ; as defined in RFC 2616, Section 2.2
 value       = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
               ; US-ASCII characters excluding CTLs,
               ; whitespace, DQUOTE, comma, semicolon,
               ; and backslash
-OWS         = <optional white space, as defined in RFC 7230, Section 3.2.3>
+OWS         = OWS ; optional white space, as defined in RFC 7230, Section 3.2.3
 ```
 
 ## Limits

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -23,12 +23,12 @@ list        = list-member 0*179( OWS "," OWS list-member )
 list-member = key OWS "=" OWS value *( OWS ";" OWS property )
 property    = key OWS "=" OWS value
 property    = key OWS
-key         = <token, as defined in RFC 2616, Section 2.2>
+key         = \<token, as defined in RFC 2616, Section 2.2\>
 value       = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
               ; US-ASCII characters excluding CTLs,
               ; whitespace, DQUOTE, comma, semicolon,
               ; and backslash
-OWS         = <optional white space, as defined in RFC 7230, Section 3.2.3>
+OWS         = \<optional white space, as defined in RFC 7230, Section 3.2.3\>
 ```
 
 ## Limits

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -3,7 +3,7 @@
 The `Baggage` header is used to propagate user-supplied key-value pairs through a distributed request.
 A received header MAY be altered to change or add information and it MUST be passed on to all downstream request.
 
-Multiple `Baggage` headers are allowed. Values can be combined in a single header according to  [RFC 7230](https://tools.ietf.org/html/rfc7230#page-24).
+Multiple `Baggage` headers are allowed. Values can be combined in a single header according to [RFC 7230](https://tools.ietf.org/html/rfc7230#page-24).
 
 *See [rationale document](HTTP_HEADER_FORMAT_RATIONALE.md) for details of decisions made for this format.*
 
@@ -14,7 +14,7 @@ Header name: `Baggage`
 
 # Header Content
 
-This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]], including the DIGIT rule in <a data-cite='!RFC5234#appendix-B.1'>appendix B.1 for RFC5234</a>. It also includes the `OWS` rule (optional whitespace) from <a data-cite='!RFC7230#whitespace'>RFC7230 section 3.2.3</a>.
+This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]].
 
 ## Definition
 
@@ -31,6 +31,9 @@ value       =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
 OWS         =  *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
 ```
 
+`token` is defined in [RFC2616, Section 2.2].
+The definition of `OWS` is taken from [RFC7230, Section 3.2.3].
+
 ## Limits
 1. Maximum number of name-value pairs: `180`.
 2. Maximum number of bytes per a single name-value pair: `4096`.
@@ -45,7 +48,7 @@ It can not be guaranteed that keys are unique.
 Consumers MUST be able to handle duplicate keys while producers SHOULD try to deduplicate the list.
 
 ### key
-ASCII string according to the `token` format, defined in [[RFC2616], Section 2.2](https://tools.ietf.org/html/rfc2616#section-2.2).
+ASCII string according to the `token` format, defined in [RFC2616, Section 2.2].
 Leading and trailing whitespaces (OWS) are allowed but MUST be trimmed when converting the header into a data structure.
 
 ### value
@@ -56,6 +59,8 @@ Leading and trailing whitespaces (OWS) are allowed but MUST be trimmed when conv
 Additional metadata MAY be appended to values in the form of property set, represented as semi-colon `;` delimited list of keys and/or key-value pairs, e.g. `;k1=v1;k2;k3=v3`. The semantic of such properties is opaque to this specification.
 Leading and trailing OWS is allowed but MUST be trimmed when converting the header into a data structure.
 
+[RFC2616, Section 2.2]: https://tools.ietf.org/html/rfc2616#section-2.2
+[RFC7230, Section 3.2.3]: tools.ietf.org/html/rfc7230#section-3.2.3
 
 # Examples of HTTP headers
 

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -18,17 +18,17 @@ This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]]
 
 ## Definition
 
-```ABNF
+```text
 list        = list-member 0*179( OWS "," OWS list-member )
 list-member = key OWS "=" OWS value *( OWS ";" OWS property )
 property    = key OWS "=" OWS value
 property    = key OWS
-key         = \<token, as defined in RFC 2616, Section 2.2\>
+key         = <token, as defined in RFC 2616, Section 2.2>
 value       = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
               ; US-ASCII characters excluding CTLs,
               ; whitespace, DQUOTE, comma, semicolon,
               ; and backslash
-OWS         = \<optional white space, as defined in RFC 7230, Section 3.2.3\>
+OWS         = <optional white space, as defined in RFC 7230, Section 3.2.3>
 ```
 
 ## Limits

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -28,7 +28,7 @@ value       = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
               ; US-ASCII characters excluding CTLs,
               ; whitespace, DQUOTE, comma, semicolon,
               ; and backslash
-OWS         = OWS ; optional white space, as defined in RFC 7230, Section 3.2.3
+OWS         = *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
 ```
 
 ## Limits

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -18,7 +18,7 @@ This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]]
 
 ## Definition
 
-```abnf
+```ABNF
 list        = list-member 0*179( OWS "," OWS list-member )
 list-member = key OWS "=" OWS value *( OWS ";" OWS property )
 property    = key OWS "=" OWS value

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -31,9 +31,9 @@ value       =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
 OWS         =  *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
 ```
 
-`token` is defined in [[!RFC2616]], Section 2.2: <https://tools.ietf.org/html/rfc2616#section-2.2>
+`token` is defined in [[!RFC2616]], Section 2.2: https://tools.ietf.org/html/rfc2616#section-2.2
 
-The definition of `OWS` is taken from [[RFC7230]], Section 3.2.3: <https://tools.ietf.org/html/rfc7230#section-3.2.3>
+The definition of `OWS` is taken from [[RFC7230]], Section 3.2.3: https://tools.ietf.org/html/rfc7230#section-3.2.3
 
 ## Limits
 1. Maximum number of name-value pairs: `180`.

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -31,8 +31,9 @@ value       =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
 OWS         =  *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
 ```
 
-`token` is defined in [RFC2616, Section 2.2].
-The definition of `OWS` is taken from [RFC7230, Section 3.2.3].
+`token` is defined in [[!RFC2616]], Section 2.2: <https://tools.ietf.org/html/rfc2616#section-2.2>
+
+The definition of `OWS` is taken from [[RFC7230]], Section 3.2.3: <https://tools.ietf.org/html/rfc7230#section-3.2.3>
 
 ## Limits
 1. Maximum number of name-value pairs: `180`.
@@ -48,7 +49,7 @@ It can not be guaranteed that keys are unique.
 Consumers MUST be able to handle duplicate keys while producers SHOULD try to deduplicate the list.
 
 ### key
-ASCII string according to the `token` format, defined in [RFC2616, Section 2.2].
+ASCII string according to the `token` format, defined in [RFC2616, Section 2.2](https://tools.ietf.org/html/rfc2616#section-2.2).
 Leading and trailing whitespaces (OWS) are allowed but MUST be trimmed when converting the header into a data structure.
 
 ### value
@@ -58,9 +59,6 @@ Leading and trailing whitespaces (OWS) are allowed but MUST be trimmed when conv
 ### property
 Additional metadata MAY be appended to values in the form of property set, represented as semi-colon `;` delimited list of keys and/or key-value pairs, e.g. `;k1=v1;k2;k3=v3`. The semantic of such properties is opaque to this specification.
 Leading and trailing OWS is allowed but MUST be trimmed when converting the header into a data structure.
-
-[RFC2616, Section 2.2]: https://tools.ietf.org/html/rfc2616#section-2.2
-[RFC7230, Section 3.2.3]: tools.ietf.org/html/rfc7230#section-3.2.3
 
 # Examples of HTTP headers
 


### PR DESCRIPTION
The current syntax using `<` and `>` seems to break the rendering by ReSpec: https://w3c.github.io/baggage/#definition

![image](https://user-images.githubusercontent.com/7052238/93908624-296b9d80-fcff-11ea-8d1b-7ae2cdf7a3ef.png)

According to its documentation (https://respec.org/docs/), ReSpec tries to guess which programming language is used in the code block. Declaring it as ABNF should do the trick.
I also removed the links since they won't be rendered or clickable anyway (neither on Github nor with ReSpec) and the RFCs are already linked elsewhere in the text.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/pull/31.html" title="Last updated on Sep 23, 2020, 10:18 PM UTC (2309b6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/31/fb5acc0...2309b6d.html" title="Last updated on Sep 23, 2020, 10:18 PM UTC (2309b6d)">Diff</a>