### PR TITLE
Simplify grammar for list-member

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -20,7 +20,7 @@ This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]]
 
 ```
 list        = list-member 0*179( OWS "," OWS list-member )
-list-member = key OWS "=" OWS value *( OWS ";" OWS property )
+list-member = property *( OWS ";" OWS property )
 property    = key OWS "=" OWS value
 property    = key OWS
 key         = <token, defined in [[RFC2616], Section 2.2](https://tools.ietf.org/html/rfc2616#section-2.2)>


### PR DESCRIPTION
The first part of the `list-member` rule is actually a `property`, so it would be easier to read and understand if that rule was referenced, rather than duplicating the definition here and thereby obfuscating that intent.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/pull/33.html" title="Last updated on Sep 22, 2020, 4:48 PM UTC (13895ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/33/0573bd7...13895ae.html" title="Last updated on Sep 22, 2020, 4:48 PM UTC (13895ae)">Diff</a>