### PR TITLE
Fix gramar: an URL -> a URL

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -49,7 +49,7 @@ ASCII string according to the `token` format, defined in [[RFC2616], Section 2.2
 Leading and trailing whitespaces (OWS) are allowed but MUST be trimmed when converting the header into a data structure.
 
 ### value
-A value contains an URL encoded UTF-8 string.
+A value contains a URL encoded UTF-8 string.
 Leading and trailing whitespaces (OWS) are allowed but MUST be trimmed when converting the header into a data structure.
 
 ### property

--- a/baggage/HTTP_HEADER_FORMAT_RATIONALE.md
+++ b/baggage/HTTP_HEADER_FORMAT_RATIONALE.md
@@ -7,7 +7,7 @@ This document provides a rationale for the decisions made for the `Baggage` head
 - It should be human-readable. Cryptic headers would hide the fact of potential information disclosure.
 - It should be append-able (comma-separated) https://tools.ietf.org/html/rfc7230#page-24 so nodes
 can add context properties without parsing existing headers.
-- Keys are a single word in ASCII, and values should be a short string in UTF-8 or a derivative of an URL.
+- Keys are a single word in ASCII, and values should be a short string in UTF-8 or a derivative of a URL.
 
 ## Why a single header?
 

--- a/baggage/HTTP_HEADER_FORMAT_RATIONALE.md
+++ b/baggage/HTTP_HEADER_FORMAT_RATIONALE.md
@@ -51,7 +51,7 @@ There are few considerations why the names should be case sensitive:
 While the semantics of header values are specific to the producer and consumer of a key/value pair, we
 concluded that string values should be encoded at the producer and decoded at the consumer and that the specification should define a mechanism for that.
 
-Url encoding is a low-overhead way to encode Unicode characters for non-Latin characters in the values. Url encoding keeps a single word in Latin unchanged and accessible.
+URL encoding is a low-overhead way to encode Unicode characters for non-Latin characters in the values. URL encoding keeps a single word in Latin unchanged and accessible.
 
 
 ## Limits


### PR DESCRIPTION
URL starts with a consonant 'y'.

Cf: https://www.google.com/search?q=a+or+an+before+u


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yurishkuro/baggage/pull/38.html" title="Last updated on Sep 22, 2020, 8:28 PM UTC (1fc95a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/38/0573bd7...yurishkuro:1fc95a8.html" title="Last updated on Sep 22, 2020, 8:28 PM UTC (1fc95a8)">Diff</a>