### PR TITLE
Canonicalize header name as baggage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing into Baggage
+# Contributing into baggage
 
 This repository is being used for work in the [W3C Distributed Trace Context Working Group](https://www.w3.org/2018/distributed-tracing/).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baggage Specification
 
-This repository is associated with the [Baggage](https://w3c.github.io/baggage/) specification.
+This repository is associated with the [baggage](https://w3c.github.io/baggage/) specification.
 
 Status of the report is
 [Editor Draft](https://www.w3.org/2017/Process-20170301/#working-draft).

--- a/abstract/baggage-overview.md
+++ b/abstract/baggage-overview.md
@@ -1,3 +1,3 @@
 # Overview
 
-The `Baggage` header represents user-defined baggage associated with the trace. Libraries and platforms MAY propagate this header.
+The `baggage` header represents user-defined baggage associated with the trace. Libraries and platforms MAY propagate this header.

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -12,6 +12,9 @@ Multiple `baggage` headers are allowed. Values can be combined in a single heade
 
 Header name: `baggage`
 
+In order to increase interoperability across multiple protocols and encourage successful integration,
+implementations SHOULD keep the header name lowercase.
+
 # Header Content
 
 This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]], including the DIGIT rule in <a data-cite='!RFC5234#appendix-B.1'>appendix B.1 for RFC5234</a>. It also includes the `OWS` rule (optional whitespace) from <a data-cite='!RFC7230#whitespace'>RFC7230 section 3.2.3</a>.

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -1,16 +1,16 @@
 # Baggage HTTP Header Format
 
-The `Baggage` header is used to propagate user-supplied key-value pairs through a distributed request.
+The `baggage` header is used to propagate user-supplied key-value pairs through a distributed request.
 A received header MAY be altered to change or add information and it MUST be passed on to all downstream request.
 
-Multiple `Baggage` headers are allowed. Values can be combined in a single header according to  [RFC 7230](https://tools.ietf.org/html/rfc7230#page-24).
+Multiple `baggage` headers are allowed. Values can be combined in a single header according to  [RFC 7230](https://tools.ietf.org/html/rfc7230#page-24).
 
 *See [rationale document](HTTP_HEADER_FORMAT_RATIONALE.md) for details of decisions made for this format.*
 
 
 # Header Name
 
-Header name: `Baggage`
+Header name: `baggage`
 
 # Header Content
 
@@ -62,36 +62,36 @@ Leading and trailing OWS is allowed but MUST be trimmed when converting the head
 Single header:
 
 ```
-Baggage: userId=sergey,serverNode=DF:28,isProduction=false
+baggage: userId=sergey,serverNode=DF:28,isProduction=false
 ```
 
 Context might be split into multiple headers:
 
 ```
-Baggage: userId=sergey
-Baggage: serverNode=DF%3A28,isProduction=false
+baggage: userId=sergey
+baggage: serverNode=DF%3A28,isProduction=false
 ```
 
 Values and names might begin and end with spaces:
 
 ```
-Baggage: userId =   sergey
-Baggage: serverNode = DF%3A28, isProduction = false
+baggage: userId =   sergey
+baggage: serverNode = DF%3A28, isProduction = false
 ```
 
 ## Example use case
 
 For example, if all of your data needs to be sent to a single node, you could propagate a property indicating that.
 ```
-Baggage: serverNode=DF:28
+baggage: serverNode=DF:28
 ```
 
 For example, if you need to log the original user ID when making transactions arbitrarily deep into a trace.
 ```
-Baggage: userId=sergey
+baggage: userId=sergey
 ```
 
 For example, if you have non-production requests that flow through the same services as production requests.
 ```
-Baggage: isProduction=false
+baggage: isProduction=false
 ```

--- a/baggage/HTTP_HEADER_FORMAT_RATIONALE.md
+++ b/baggage/HTTP_HEADER_FORMAT_RATIONALE.md
@@ -1,6 +1,6 @@
 # Baggage Header Format Rationale
 
-This document provides a rationale for the decisions made for the `Baggage` header format.
+This document provides a rationale for the decisions made for the `baggage` header format.
 
 ## General considerations
 
@@ -15,7 +15,7 @@ Another option would be to use prefixed headers, such as `trace-context-X`, wher
 field name. That could reduce the size of the data, particularly in http/2, where header
 compression can apply.
 
-Generally speaking, a `Baggage` header may be split into multiple headers, and
+Generally speaking, a `baggage` header may be split into multiple headers, and
 compression may be at the same ballpark as repeating values are converted into a single value
 in HPAC's dynamic collection. That said, there was no profiling made to make this decision.
 
@@ -29,13 +29,13 @@ name.
 
 The [Vary](https://tools.ietf.org/html/rfc7231#section-7.1.4) approach is another alternative,
 where a fixed header is used to enumerate the list of other headers that actually contain the data.
-which could be used to accomplish the same. For example, `Baggage: x-department; x-user-id;
+which could be used to accomplish the same. For example, `baggage: x-department; x-user-id;
 ttl=1` could tell the propagation to look at and forward the parent ID header, but only to the
 next hop. This has an advantage of HTTP header compression (hpack) and also weave-in with legacy
 tracing headers.
 
 Vary approach may be implemented as a new "header reference" value type `ref`.
-`Baggage: x-b3-parentid;type=ref;ttl=1` if proven needed.
+`baggage: x-b3-parentid;type=ref;ttl=1` if proven needed.
 
 ## Trimming of spaces
 
@@ -57,7 +57,7 @@ Url encoding is a low-overhead way to encode Unicode characters for non-Latin ch
 ## Limits
 
 The idea behind limits is to provide trace vendors standard safeguards so the content of the
-`Baggage` header can be stored with the request. Thus the limits are defined on the
+`baggage` header can be stored with the request. Thus the limits are defined on the
 number of keys, max pair length, and the total size. The total size limit is the most important for planning data storage requirements.
 
 Another consideration was that HTTP cookies provide a similar way to pass custom data via HTTP

--- a/baggage/HTTP_HEADER_FORMAT_RATIONALE.md
+++ b/baggage/HTTP_HEADER_FORMAT_RATIONALE.md
@@ -41,6 +41,13 @@ Vary approach may be implemented as a new "header reference" value type `ref`.
 
 The header should be human-readable and editable. Thus spaces are allowed before and after the comma, equal sign, and semicolon separators. It makes manual editing of headers less error-prone. It also allows better visual separation of fields when value modified manually.
 
+## Lowercase header name
+
+In order to maximize the portability of the `baggage` header it is intentionally specified as a single lowercase word.
+While HTTP header names are case-insensitive, the `baggage` header is meant to be propagated over other protocols that have
+different constraints. Representing the header as a single lowercase word maximizes the use and reduces the chance of error
+when using the header in non-HTTP scenarios.
+
 ## Case sensitivity of keys
 
 There are few considerations why the names should be case sensitive:

--- a/baggage/README.md
+++ b/baggage/README.md
@@ -1,6 +1,6 @@
 # Baggage Header
 
-`Baggage` header is used to propagate properties not defined in `Trace-Parent`. There
+`baggage` header is used to propagate properties not defined in `traceparent`. There
 are two common use cases. First is to define a context on trace initiation. Such context will
 have customer's identity, high-level operation name and other properties like a flight name.
 Second use case is to pass the caller's name to the next component. This name-value pair will be


### PR DESCRIPTION
As discussed during the bi-weekly meeting earlier. we'd like to canonicalize the header name as baggage (with a lowercase b). The reasons are the same for baggage as they were for tracecontext, and traceparent, namely, to maximize the use of the header for non-HTTP scenarios, and reduce errors when propagating it. This PR updates the spec to refer to the header as `baggage` and adds a section describing the the rationale.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mwear/correlation-context/pull/39.html" title="Last updated on Sep 23, 2020, 10:12 PM UTC (20d9900)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/39/3c52a2d...mwear:20d9900.html" title="Last updated on Sep 23, 2020, 10:12 PM UTC (20d9900)">Diff</a>