### PR TITLE
Grammar nits

### DIFF
--- a/abstract/baggage-overview.md
+++ b/abstract/baggage-overview.md
@@ -1,3 +1,3 @@
 # Overview
 
-The `baggage` header represents user-defined baggage associated with the trace. Libraries and platforms MAY propagate this header.
+The `baggage` header represents user-defined baggage associated with a trace. Libraries and platforms MAY propagate this header.

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -1,7 +1,7 @@
 # Baggage HTTP Header Format
 
 The `baggage` header is used to propagate user-supplied key-value pairs through a distributed request.
-A received header MAY be altered to change or add information and it MUST be passed on to all downstream request.
+A received header MAY be altered to change or add information and it MUST be passed on to all downstream requests.
 
 Multiple `baggage` headers are allowed. Values can be combined in a single header according to [RFC 7230](https://tools.ietf.org/html/rfc7230#page-24).
 


### PR DESCRIPTION
Fixing two minor grammatical issues. These changes are non-substantive.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/pull/42.html" title="Last updated on Sep 23, 2020, 10:36 PM UTC (95043ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/42/ea1d4e9...95043ce.html" title="Last updated on Sep 23, 2020, 10:36 PM UTC (95043ce)">Diff</a>