### PR TITLE
fix #34: note, that equal sign can be used in the value

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -51,6 +51,9 @@ Leading and trailing whitespaces (OWS) are allowed but MUST be trimmed when conv
 A value contains a URL encoded UTF-8 string.
 Leading and trailing whitespaces (OWS) are allowed but MUST be trimmed when converting the header into a data structure.
 
+Note, `value` MAY contain any number of the equal sign (`=`) characters. Parsers
+MUST NOT assume that the equal sign is only used to separate `key` and `value`.
+
 ### property
 Additional metadata MAY be appended to values in the form of property set, represented as semi-colon `;` delimited list of keys and/or key-value pairs, e.g. `;k1=v1;k2;k3=v3`. The semantic of such properties is opaque to this specification.
 Leading and trailing OWS is allowed but MUST be trimmed when converting the header into a data structure.


### PR DESCRIPTION
Fixes #34


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 6, 2021, 5:57 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fbaggage%2F00a70dd8771b08d91343bcb4f1e538f8688a5f31%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 429: https://rawcdn.githack.com/w3c/baggage/00a70dd8771b08d91343bcb4f1e538f8688a5f31/index.html
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/baggage%2346.)._
</details>
