### PR TITLE
Extend ABNF to allow multi-octet values

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -22,16 +22,17 @@ This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]]
 ## Definition
 
 ```ABNF
-list        =  list-member 0*179( OWS "," OWS list-member )
-list-member =  key OWS "=" OWS value *( OWS ";" OWS property )
-property    =  key OWS "=" OWS value
-property    =/ key OWS
-key         =  token ; as defined in RFC 2616, Section 2.2
-value       =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
-               ; US-ASCII characters excluding CTLs,
-               ; whitespace, DQUOTE, comma, semicolon,
-               ; and backslash
-OWS         =  *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
+list           =  list-member 0*179( OWS "," OWS list-member )
+list-member    =  key OWS "=" OWS value *( OWS ";" OWS property )
+property       =  key OWS "=" OWS value
+property       =/ key OWS
+key            =  token ; as defined in RFC 2616, Section 2.2
+value          =  *baggage-octet
+baggage-octet  =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
+                  ; US-ASCII characters excluding CTLs,
+                  ; whitespace, DQUOTE, comma, semicolon,
+                  ; and backslash
+OWS            =  *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
 ```
 
 `token` is defined in [[!RFC2616]], Section 2.2: https://tools.ietf.org/html/rfc2616#section-2.2


### PR DESCRIPTION
Fixes #56


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dyladan/baggage/pull/57.html" title="Last updated on Apr 20, 2021, 5:01 PM UTC (0cf91fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/57/f39a15a...dyladan:0cf91fc.html" title="Last updated on Apr 20, 2021, 5:01 PM UTC (0cf91fc)">Diff</a>