### PR TITLE
Move non-format information to overview and expand

### DIFF
--- a/abstract/baggage-overview.md
+++ b/abstract/baggage-overview.md
@@ -1,5 +1,6 @@
 # Overview
 
-The `baggage` header represents user-defined baggage associated with a trace. Libraries and platforms SHOULD propagate this header.
-The `baggage` header is used to propagate user-supplied key-value pairs through a distributed request.
-A received header MAY be altered to change or add information and it SHOULD be propagated to all downstream requests.
+The `baggage` header is used to propagate user-supplied key-value pairs and associated metadata through a distributed request.
+These key-value pairs MAY be used for debugging, changing application behavior, communicating information about upstream services to downstream services, or other uses not listed here.
+This specification does not define any particular header keys, values, or metadata, and it does not assign any specific meaning to the data being propagated.
+A received header SHOULD be propagated to all downstream requests, though it MAY be altered to add, change, or remove any or all key-value pairs or metadata.

--- a/abstract/baggage-overview.md
+++ b/abstract/baggage-overview.md
@@ -1,3 +1,5 @@
 # Overview
 
 The `baggage` header represents user-defined baggage associated with a trace. Libraries and platforms SHOULD propagate this header.
+The `baggage` header is used to propagate user-supplied key-value pairs through a distributed request.
+A received header MAY be altered to change or add information and it SHOULD be propagated to all downstream requests.

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -2,7 +2,7 @@
 
 The `baggage` header is a list of unordered key-value pairs with associated metadata.
 Multiple `baggage` headers are allowed.
-Values can be combined in a single header according to [RFC 7230](https://tools.ietf.org/html/rfc7230#page-24).
+Multiple `baggage` headers MAY be combined in a single header according to [RFC 7230](https://tools.ietf.org/html/rfc7230#page-24).
 
 ## Header Name
 

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -1,9 +1,8 @@
 # Baggage HTTP Header Format
 
-The `baggage` header is used to propagate user-supplied key-value pairs through a distributed request.
-A received header MAY be altered to change or add information and it SHOULD be passed on to all downstream requests.
-
-Multiple `baggage` headers are allowed. Values can be combined in a single header according to [RFC 7230](https://tools.ietf.org/html/rfc7230#page-24).
+The `baggage` header is a list of unordered key-value pairs with associated metadata.
+Multiple `baggage` headers are allowed.
+Values can be combined in a single header according to [RFC 7230](https://tools.ietf.org/html/rfc7230#page-24).
 
 ## Header Name
 


### PR DESCRIPTION
As discussed in the meeting on July 6 2021, the first paragraph of the format section contained information more appropriate for an overview.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dyladan/baggage/pull/72.html" title="Last updated on Aug 3, 2021, 9:41 PM UTC (4dc50d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/72/404901a...dyladan:4dc50d4.html" title="Last updated on Aug 3, 2021, 9:41 PM UTC (4dc50d4)">Diff</a>