### PR TITLE
Move Daniel Khan to former editors

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,11 +15,6 @@
         w3cid: "103966"
       },
       {
-        name: "Daniel Khan",
-        company: "Dynatrace",
-        w3cid: "90530"
-      },
-      {
         name: "Yuri Shkuro",
         company: "Facebook",
         w3cid: "104074"
@@ -35,6 +30,12 @@
         company: "Google",
         companyURL: "https://google.com",
         w3cid: "104128"
+      },
+      {
+        name: "Daniel Khan",
+        company: "Dynatrace",
+        companyURL: "https://dynatrace.com",
+        w3cid: "90530"
       }],
       github: {
         repoURL: "https://github.com/w3c/baggage/",


### PR DESCRIPTION
Now that Daniel is no longer in w3.org/groups/wg/distributed-tracing/participants he should be moved to the former editors section. Thank you Daniel for all your hard work!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dyladan/baggage/pull/76.html" title="Last updated on Aug 4, 2021, 2:03 PM UTC (55d52e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/76/404901a...dyladan:55d52e4.html" title="Last updated on Aug 4, 2021, 2:03 PM UTC (55d52e4)">Diff</a>