### PR TITLE
Apply url encoding to single header example, matching multiple

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -89,7 +89,7 @@ baggage: key1=value1;property1;property2, key2 = value2, key3=value3; propertyKe
 Single header:
 
 ```
-baggage: userId=alice,serverNode=DF:28,isProduction=false
+baggage: userId=alice,serverNode=DF%3A28,isProduction=false
 ```
 
 Context might be split into multiple headers:

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -86,7 +86,7 @@ baggage: key1=value1;property1;property2, key2 = value2, key3=value3; propertyKe
 
 ## Examples of HTTP headers
 
-When propagating the entries (userId, alice), (serverNode, DF 28), (isProduction, false),
+Assume we want to propagate these entries: `userId="alice"`, `serverNode="DF 28"`, `isProduction=false`,
 
 Single header:
 

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -86,24 +86,26 @@ baggage: key1=value1;property1;property2, key2 = value2, key3=value3; propertyKe
 
 ## Examples of HTTP headers
 
+When propagating the entries (userId, alice), (serverNode, DF 28), (isProduction, false),
+
 Single header:
 
 ```
-baggage: userId=alice,serverNode=DF%3A28,isProduction=false
+baggage: userId=alice,serverNode=DF%2028,isProduction=false
 ```
 
 Context might be split into multiple headers:
 
 ```
 baggage: userId=alice
-baggage: serverNode=DF%3A28,isProduction=false
+baggage: serverNode=DF%2028,isProduction=false
 ```
 
 Values and names might begin and end with spaces:
 
 ```
 baggage: userId =   alice
-baggage: serverNode = DF%3A28, isProduction = false
+baggage: serverNode = DF%2028, isProduction = false
 ```
 
 ### Example use case
@@ -111,7 +113,7 @@ baggage: serverNode = DF%3A28, isProduction = false
 For example, if all of your data needs to be sent to a single node, you could propagate a property indicating that.
 
 ```
-baggage: serverNode=DF:28
+baggage: serverNode=DF%2028
 ```
 
 For example, if you need to annotate logs with some request-specific information, you could propagate a property using the baggage header.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/anuraaga/correlation-context/pull/78.html" title="Last updated on Dec 8, 2021, 4:07 PM UTC (2060adb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/78/f45f946...anuraaga:2060adb.html" title="Last updated on Dec 8, 2021, 4:07 PM UTC (2060adb)">Diff</a>