### PR TITLE
Use RFC 7230 for token definition

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -23,7 +23,7 @@ baggage-string         =  list-member 0*179( OWS "," OWS list-member )
 list-member            =  key OWS "=" OWS value *( OWS ";" OWS property )
 property               =  key OWS "=" OWS value
 property               =/ key OWS
-key                    =  token ; as defined in RFC 2616, Section 2.2
+key                    =  token ; as defined in RFC 7230, Section 3.2.6
 value                  =  *baggage-octet
 baggage-octet          =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
                           ; US-ASCII characters excluding CTLs,
@@ -32,7 +32,7 @@ baggage-octet          =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
 OWS                    =  *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
 ```
 
-`token` is defined in [[!RFC2616]], Section 2.2: https://tools.ietf.org/html/rfc2616#section-2.2
+`token` is defined in [[!RFC7230]], Section 3.2.6: https://tools.ietf.org/html/rfc7230#section-3.2.6
 
 The definition of `OWS` is taken from [[RFC7230]], Section 3.2.3: https://tools.ietf.org/html/rfc7230#section-3.2.3
 
@@ -45,7 +45,7 @@ Producers SHOULD try to produce a `baggage-string` without any `list-member`s wh
 
 #### key
 
-ASCII string according to the `token` format, defined in [RFC2616, Section 2.2](https://tools.ietf.org/html/rfc2616#section-2.2).
+A `token` which identifies a `value` in the `baggage`. `token` is defined in [RFC7230, Section 3.2.6](https://tools.ietf.org/html/rfc7230#section-3.2.6).
 Leading and trailing whitespaces (`OWS`) are allowed but MUST be trimmed when converting the header into a data structure.
 
 #### value


### PR DESCRIPTION
Resolves the issue raised by https://github.com/w3ctag/design-reviews/issues/650#issuecomment-969290866

Changes the definition of `token` to refer to RFC 7230 instead of RFC 2616. RFC 7230 is already used for the definition of OWS and for header concatenation rules. IMO the new definition is more clear and easily readable.

Note: The definitions are written differently. The old 2616 definition defines token in terms of what characters ARE NOT allowed (separators). The new 7230 definition defines token in terms of which characters ARE allowed. The definitions appear to be identical as far as I can tell. There are 72 allowed characters in the US ASCII range (0-127).

Old token definition from 2616:

```
       CHAR           = <any US-ASCII character (octets 0 - 127)>
       CTL            = <any US-ASCII control character
                        (octets 0 - 31) and DEL (127)>

       token          = 1*<any CHAR except CTLs or separators>
       separators     = "(" | ")" | "<" | ">" | "@"
                      | "," | ";" | ":" | "\" | <">
                      | "/" | "[" | "]" | "?" | "="
                      | "{" | "}" | SP | HT
```

New token definition from 7230:

```
     VCHAR defined as any visible [USASCII] character

     token          = 1*tchar

     tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
                    / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
                    / DIGIT / ALPHA
                    ; any VCHAR, except delimiters
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dyladan/baggage/pull/79.html" title="Last updated on Dec 7, 2021, 7:47 PM UTC (23a08fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/79/404901a...dyladan:23a08fe.html" title="Last updated on Dec 7, 2021, 7:47 PM UTC (23a08fe)">Diff</a>