### PR TITLE
Clarify what implementations should do when baggage length is exceeded or when invalid entry is found

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -137,3 +137,7 @@ The following mutations are allowed:
 * **Update an existing value.** The value for any given key MAY be updated.
 * **Delete a key/value pair.** Any key/value pair MAY be deleted.
 * **Deduplicating the list.** Duplicate keys MAY be removed.
+
+If a system receiving or updating a `baggage` request header determines that the number of baggage entries exceeds the limit defined in the limits section above, it MAY drop or truncate certain baggage entries in any order chosen by the implementation.
+
+If a system determines that the value of a baggage entry is not in the format defined in this specification, it MAY remove that entry before propagating the baggage header as part of outgoing requests.


### PR DESCRIPTION
Resolves issue #80. Clarifies what implementations should do when baggage length is exceeded or when invalid entry is found.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kalyanaj/baggage/pull/82.html" title="Last updated on Dec 7, 2021, 10:51 PM UTC (a114e3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/82/b9317d7...kalyanaj:a114e3d.html" title="Last updated on Dec 7, 2021, 10:51 PM UTC (a114e3d)">Diff</a>