### PR TITLE
Remove unenforceable requirement to strip whitespace

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -46,20 +46,21 @@ Producers SHOULD try to produce a `baggage-string` without any `list-member`s wh
 #### key
 
 A `token` which identifies a `value` in the `baggage`. `token` is defined in [RFC7230, Section 3.2.6](https://tools.ietf.org/html/rfc7230#section-3.2.6).
-Leading and trailing whitespaces (`OWS`) are allowed but MUST be trimmed when converting the header into a data structure.
+Leading and trailing whitespaces (`OWS`) are allowed.
 
 #### value
 
 A value contains a URL encoded UTF-8 string.
-Leading and trailing whitespaces (`OWS`) are allowed but MUST be trimmed when converting the header into a data structure.
+Leading and trailing whitespaces (`OWS`) are allowed.
 
 Note, `value` MAY contain any number of the equal sign (`=`) characters. Parsers
 MUST NOT assume that the equal sign is only used to separate `key` and `value`.
 
 #### property
 
-Additional metadata MAY be appended to values in the form of property set, represented as semi-colon `;` delimited list of keys and/or key-value pairs, e.g. `;k1=v1;k2;k3=v3`. The semantic of such properties is <a>opaque</a> to this specification.
-Leading and trailing `OWS` is allowed but MUST be trimmed when converting the header into a data structure.
+Additional metadata MAY be appended to values in the form of property set, represented as semi-colon `;` delimited list of keys and/or key-value pairs, e.g. `;k1=v1;k2;k3=v3`. 
+The semantic of such properties is <a>opaque</a> to this specification.
+Leading and trailing `OWS` is allowed.
 
 ### Limits
 

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -46,12 +46,12 @@ Producers SHOULD try to produce a `baggage-string` without any `list-member`s wh
 #### key
 
 A `token` which identifies a `value` in the `baggage`. `token` is defined in [RFC7230, Section 3.2.6](https://tools.ietf.org/html/rfc7230#section-3.2.6).
-Leading and trailing whitespaces (`OWS`) are allowed.
+Leading and trailing whitespaces (`OWS`) are allowed and are not considered to be a part of the key.
 
 #### value
 
 A value contains a URL encoded UTF-8 string.
-Leading and trailing whitespaces (`OWS`) are allowed.
+Leading and trailing whitespaces (`OWS`) are allowed and are not considered to be a part of the value.
 
 Note, `value` MAY contain any number of the equal sign (`=`) characters. Parsers
 MUST NOT assume that the equal sign is only used to separate `key` and `value`.
@@ -60,7 +60,7 @@ MUST NOT assume that the equal sign is only used to separate `key` and `value`.
 
 Additional metadata MAY be appended to values in the form of property set, represented as semi-colon `;` delimited list of keys and/or key-value pairs, e.g. `;k1=v1;k2;k3=v3`. 
 The semantic of such properties is <a>opaque</a> to this specification.
-Leading and trailing `OWS` is allowed.
+Leading and trailing `OWS` is allowed and is not considered to be a part of the property key or value.
 
 ### Limits
 


### PR DESCRIPTION
Requiring OWS to be stripped when the header is parsed into a data structure is unenforceable and unnecessarily prescriptive. This specification deals with the wire format, not the in-memory representation of the data it carries. OWS should either be allowed or not and the implementer can decide if it should be stripped.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dyladan/baggage/pull/87.html" title="Last updated on Mar 2, 2022, 2:05 PM UTC (d7c02de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/87/26ae597...dyladan:d7c02de.html" title="Last updated on Mar 2, 2022, 2:05 PM UTC (d7c02de)">Diff</a>