### PR TITLE
Define lower bounds for header limits

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -67,6 +67,7 @@ Leading and trailing `OWS` is allowed and is not considered to be a part of the 
 Note that the following limits are _minimum_ requirements to comply with the specification.
 An implementor or platform MAY define higher limits and SHOULD propagate as much baggage information as is reasonable within their requirements.
 If a platform cannot propagate all baggage, it MUST NOT propagate any partial `list-member`s.
+If there are multiple `baggage` headers, all limits apply to the combination of all `baggage` headers and not each header individually.
 
 1. A platform MUST propagate all `list-member`s up to _at least_ 64 `list-member`s including any `list-member`s added by the platform.
 2. A platform MUST propagate all `list-member`s including any `list-member`s added by the platform if the resulting `baggage-string` would be 8192 bytes or less. If the resulting `baggage-string` would be greater than 8192 bytes, some `list-member`s MAY be dropped until the resulting `baggage-string` is 8192 characters or less.

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -63,9 +63,11 @@ Leading and trailing `OWS` is allowed but MUST be trimmed when converting the he
 
 ### Limits
 
-1. Maximum number of `list-member`s: `180`.
-2. Maximum number of bytes per `list-member`: `4096`.
-3. Maximum number of bytes per `baggage-string`: `8192`.
+Note that the following limits are _minimum_ requirements to comply with the specification.
+An implementor or platform MAY define higher limits and SHOULD propagate as much baggage information as is reasonable within their requirements.
+
+1. A platform MUST propagate _at least_ 64 `list-member`s.
+2. A platform MUST propagate a `baggage-string` of _at least_ 8192 bytes.
 
 ### Example
 

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -66,9 +66,12 @@ Leading and trailing `OWS` is allowed and is not considered to be a part of the 
 
 Note that the following limits are _minimum_ requirements to comply with the specification.
 An implementor or platform MAY define higher limits and SHOULD propagate as much baggage information as is reasonable within their requirements.
+If a platform cannot propagate all baggage, it MUST NOT propagate any partial `list-member`s.
 
-1. A platform MUST propagate _at least_ 64 `list-member`s.
-2. A platform MUST propagate a `baggage-string` of _at least_ 8192 bytes.
+1. A platform MUST propagate all `list-member`s up to _at least_ 64 `list-member`s including any `list-member`s added by the platform.
+2. A platform MUST propagate all `list-member`s including any `list-member`s added by the platform if the resulting `baggage-string` would be 8192 bytes or less. If the resulting `baggage-string` would be greater than 8192 bytes, some `list-member`s MAY be dropped until the resulting `baggage-string` is 8192 characters or less.
+
+If a platform does not propagate all `list-member`s, it is left to the implementer to decide which `list-member`s to propagate.
 
 ### Example
 


### PR DESCRIPTION
Fixes #65

1. Remove the current upper bound limits (8192 total bytes, 180 entries, 4096 bytes per entry)
2. Define the following minimum propagation requirements:
	1. _At least_ 64 entries MUST be propagated
	2. _At least_ 8192 bytes including delimiters MUST be propagated

Provides the following benefits:

- A user can reliably assume 64 entries with length of 127 characters or less will be propagated
- A platform vendor with additional resources can enable much higher limits for their users as these are only _minimum_ requirements, enabling use cases for their users which use more than 64 entries or which use longer entries.
- A platform vendor with very strict processing requirements can track changes with a 64-bit bit set and allocate a fixed-length buffer for serialization.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dyladan/baggage/pull/89.html" title="Last updated on Apr 12, 2022, 5:44 PM UTC (0375880)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/89/ecdaa17...dyladan:0375880.html" title="Last updated on Apr 12, 2022, 5:44 PM UTC (0375880)">Diff</a>