### PR TITLE
Add example of percent-encoding non-ASCII characters in value field of a baggage list member

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -107,6 +107,12 @@ Single header:
 baggage: userId=alice,serverNode=DF%2028,isProduction=false
 ```
 
+Here is one more example where values with characters outside of the `baggage-octet` range of characters are percent-encoded. Consider the entry: `userId="Amélie"`, `serverNode="DF 28"`, `isProduction=false`:
+
+```
+baggage: userId=Am%C3%A9lie,serverNode=DF%2028,isProduction=false
+```
+
 Context might be split into multiple headers:
 
 ```


### PR DESCRIPTION
Resolves #98


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kalyanaj/baggage/pull/102.html" title="Last updated on Jun 8, 2022, 4:28 PM UTC (ee4593f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/102/d7ffe09...kalyanaj:ee4593f.html" title="Last updated on Jun 8, 2022, 4:28 PM UTC (ee4593f)">Diff</a>