### PR TITLE
ReSpec fix

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -50,7 +50,7 @@ Leading and trailing whitespaces (`OWS`) are allowed and are not considered to b
 
 #### value
 
-A value contains a string whose character encoding MUST be UTF-8 [Encoding].
+A value contains a string whose character encoding MUST be UTF-8 [[Encoding]].
 Any characters outside of the `baggage-octet` range of characters MUST be percent-encoded.
 Characters which are not required to be percent-encoded MAY be percent-encoded.
 Percent-encoding is defined in [[RFC3986]], Section 2.1: https://datatracker.ietf.org/doc/html/rfc3986#section-2.1.


### PR DESCRIPTION
Fix the [ReSpec syntax](https://respec.org/docs/#references-0) for referring to the [Encoding Standard](https://encoding.spec.whatwg.org/).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/pull/103.html" title="Last updated on Jun 10, 2022, 12:24 AM UTC (c360b54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/103/ab2bc5a...c360b54.html" title="Last updated on Jun 10, 2022, 12:24 AM UTC (c360b54)">Diff</a>