### PR TITLE
Add note that applications using baggage must be aware that data can be propagated to other systems

### DIFF
--- a/abstract/common-abstract.md
+++ b/abstract/common-abstract.md
@@ -1,3 +1,5 @@
 This specification defines a standard for representing and propagating a set of application-defined properties associated with a distributed request or workflow execution.
 
 This is independent of the [Trace Context](https://www.w3.org/TR/trace-context/) specification. Baggage can be used regardless of whether Distributed Tracing is used. This specification standardizes representation and propagation of application-defined properties. In contrast, Trace Context specification standardizes representation and propagation of the metadata needed to enable Distributed Tracing scenarios.
+
+The current version of the Baggage specification is targeted for implementations by applications and services, including web applications running within a browser. Web Browsers or User Agents are not currently in scope as a target implementation.

--- a/baggage/privacy.md
+++ b/baggage/privacy.md
@@ -11,4 +11,4 @@ Systems MUST assess the risk of header abuse. This section provides some conside
 The main purpose of this header is to provide additional system-specific information to other systems within the same trust-boundary.
 The `baggage` header may contain any value in any of the keys.
 As such, the `baggage` header can contain user-identifiable data, however no key or its value or properties is given semantic meaning by this specification.
-Applications using baggage should be aware that, when they use baggage, the keys and values can be propagated to other systems. Hence, they should remove any private information that they don't want to be propagated to other systems. If applications decide to retain any sensitive information, they should ensure that the channel used to transport such data is secured.
+Applications using baggage should be aware that the keys and values can be propagated to other systems. Hence, they should remove any private information that they don't want to be propagated to other systems.

--- a/baggage/privacy.md
+++ b/baggage/privacy.md
@@ -11,4 +11,4 @@ Systems MUST assess the risk of header abuse. This section provides some conside
 The main purpose of this header is to provide additional system-specific information to other systems within the same trust-boundary.
 The `baggage` header may contain any value in any of the keys.
 As such, the `baggage` header can contain user-identifiable data, however no key or its value or properties is given semantic meaning by this specification.
-Systems MUST ensure that the `baggage` header does not leak beyond defined trust boundaries and they MUST ensure that the channel that is used to transport potentially user-identifiable data is secured.
+Applications using baggage should be aware that, when they use baggage, the keys and values can be propagated to other systems. Hence, they should remove any private information that they don't want to be propagated to other systems. If applications decide to retain any sensitive information, they should ensure that the channel used to transport such data is secured.

--- a/baggage/security.md
+++ b/baggage/security.md
@@ -9,4 +9,4 @@ Application owners should either ensure that no proprietary or confidential info
 
 
 ## Other Risks
-Application owners need to make sure to test all code paths leading to the sending of the `baggage` header. For example, in single page browser applications, it is typical to make cross-origin requests. If one of these code paths leads to `baggage` headers being sent by cross-origin calls that are restricted using <a data-cite='FETCH#http-access-control-request-headers'>`Access-Control-Allow-Headers`</a> [[FETCH]], it may fail.
+Application owners need to make sure to test all code paths leading to the sending of the `baggage` header. For example, in web applications written in JavaScript, it is typical to make cross-origin requests. If one of these code paths leads to `baggage` headers being sent by cross-origin calls that are restricted using <a data-cite='FETCH#http-access-control-request-headers'>`Access-Control-Allow-Headers`</a> [[FETCH]], it may fail.


### PR DESCRIPTION
Add note that applications using baggage must be aware that data can be propagated to other systems. Resolves #107.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kalyanaj/baggage/pull/111.html" title="Last updated on Dec 21, 2022, 2:21 AM UTC (0868629)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/111/266e6e4...kalyanaj:0868629.html" title="Last updated on Dec 21, 2022, 2:21 AM UTC (0868629)">Diff</a>