### PR TITLE
Allow unicode in baggage keys by referencing XML

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -23,7 +23,6 @@ baggage-string         =  list-member 0*179( OWS "," OWS list-member )
 list-member            =  key OWS "=" OWS value *( OWS ";" OWS property )
 property               =  key OWS "=" OWS value
 property               =/ key OWS
-key                    =  token ; as defined in RFC 7230, Section 3.2.6
 value                  =  *baggage-octet
 baggage-octet          =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
                           ; US-ASCII characters excluding CTLs,
@@ -31,8 +30,6 @@ baggage-octet          =  %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
                           ; and backslash
 OWS                    =  *( SP / HTAB ) ; optional white space, as defined in RFC 7230, Section 3.2.3
 ```
-
-`token` is defined in [[!RFC7230]], Section 3.2.6: https://tools.ietf.org/html/rfc7230#section-3.2.6
 
 The definition of `OWS` is taken from [[RFC7230]], Section 3.2.3: https://tools.ietf.org/html/rfc7230#section-3.2.3
 
@@ -45,7 +42,8 @@ Producers SHOULD try to produce a `baggage-string` without any `list-member`s wh
 
 #### key
 
-A `token` which identifies a `value` in the `baggage`. `token` is defined in [RFC7230, Section 3.2.6](https://tools.ietf.org/html/rfc7230#section-3.2.6).
+A `key` which identifies a `value` in the `baggage`.
+`key` is defined as `Name` in [[XML]], Section 2.3: https://www.w3.org/TR/xml/#NT-Name
 Leading and trailing whitespaces (`OWS`) are allowed and are not considered to be a part of the key.
 
 #### value


### PR DESCRIPTION
Alternative to #117 which relies on an external definition for keys


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dyladan/baggage/pull/120.html" title="Last updated on Jun 6, 2023, 7:29 PM UTC (ad57816)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/120/bbed5f0...dyladan:ad57816.html" title="Last updated on Jun 6, 2023, 7:29 PM UTC (ad57816)">Diff</a>