### PR TITLE
Percent character in value MUST be percent-encoded

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -52,7 +52,7 @@ Leading and trailing whitespaces (`OWS`) are allowed and are not considered to b
 
 A value contains a string whose character encoding MUST be UTF-8 [[Encoding]].
 Any characters outside of the `baggage-octet` range of characters MUST be percent-encoded.
-The precent character MUST be percent-encoded.
+The percent character MUST be percent-encoded.
 Characters which are not required to be percent-encoded MAY be percent-encoded.
 Percent-encoding is defined in [[RFC3986]], Section 2.1: https://datatracker.ietf.org/doc/html/rfc3986#section-2.1.
 

--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -52,6 +52,7 @@ Leading and trailing whitespaces (`OWS`) are allowed and are not considered to b
 
 A value contains a string whose character encoding MUST be UTF-8 [[Encoding]].
 Any characters outside of the `baggage-octet` range of characters MUST be percent-encoded.
+The precent character MUST be percent-encoded.
 Characters which are not required to be percent-encoded MAY be percent-encoded.
 Percent-encoding is defined in [[RFC3986]], Section 2.1: https://datatracker.ietf.org/doc/html/rfc3986#section-2.1.
 


### PR DESCRIPTION
Fixes https://github.com/w3c/baggage/issues/124


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pellared/baggage/pull/125.html" title="Last updated on Dec 20, 2023, 5:02 PM UTC (49b795b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/125/ebda53c...pellared:49b795b.html" title="Last updated on Dec 20, 2023, 5:02 PM UTC (49b795b)">Diff</a>