### PR TITLE
fix: replace two instances of "Context" by "Baggage"

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -132,7 +132,7 @@ Here is one more example where values with characters outside of the `baggage-oc
 baggage: userId=Am%C3%A9lie,serverNode=DF%2028,isProduction=false
 ```
 
-Context might be split into multiple headers:
+Baggage might be split into multiple headers:
 
 ```
 baggage: userId=alice

--- a/baggage/HTTP_HEADER_FORMAT_RATIONALE.md
+++ b/baggage/HTTP_HEADER_FORMAT_RATIONALE.md
@@ -6,7 +6,7 @@ This document provides a rationale for the decisions made for the `baggage` head
 
 - It should be human-readable. Cryptic headers would hide the fact of potential information disclosure.
 - It should be appendable (comma-separated) https://tools.ietf.org/html/rfc7230#page-24 so nodes
-can add context properties without parsing existing headers.
+can add baggage properties without parsing existing headers.
 - Keys are a single word in ASCII, and values should be a short string in UTF-8 or a derivative of a URL.
 
 ## Why a single header?


### PR DESCRIPTION
The term "context" should not be used when referring to baggage, to avoid confusion with the trace context spec. The two usages replaced in this commit are from prehistoric times (e.g. commit 35a30346 from 2017) when baggage was still called correlation context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/basti1302/baggage/pull/143.html" title="Last updated on Oct 7, 2024, 3:42 PM UTC (7ab0408)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/143/8c215ef...basti1302:7ab0408.html" title="Last updated on Oct 7, 2024, 3:42 PM UTC (7ab0408)">Diff</a>