### PR TITLE
Clarify that the behavior for handling invalid baggage string values is undefined

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -180,4 +180,4 @@ The following mutations are allowed:
 
 If a system receiving or updating a `baggage` request header determines that the number of baggage entries exceeds the limit defined in the limits section above, it MAY drop or truncate certain baggage entries in any order chosen by the implementation.
 
-If a system determines that the value of a baggage entry is not in the format defined in this specification, it MAY remove that entry before propagating the baggage header as part of outgoing requests.
+If a system determines that the value of `baggage-string` is not in the format defined in this specification, the behavior is undefined. For example, it MAY remove an offending `list-member` before propagating the rest of the `baggage-string`, or MAY decide to not propagate the `baggage-string` at all.


### PR DESCRIPTION
Clarify that the behavior for handling invalid baggage string values is undefined.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kalyanaj/baggage/pull/144.html" title="Last updated on Oct 8, 2024, 12:47 AM UTC (bc4b9b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/144/8c215ef...kalyanaj:bc4b9b9.html" title="Last updated on Oct 8, 2024, 12:47 AM UTC (bc4b9b9)">Diff</a>