### PR TITLE
fix: Readme "Why" Link is broken.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,7 @@ Another system that supports the baggage concept is .NET. It supports it as part
 
 ## Why are we doing this
 
-- If this becomes popular, frameworks and other services will automatically pass trace IDs
-through for correlated requests. This would prevent traces from hitting dead ends when a request
-reaches an un-instrumented service.
-- Once aligned on a header name, we can ask for a CORS exception from the W3C. This would allow
-browsers to attach trace IDs to requests and submit tracing data to a distributed tracing service.
-- Loggers can reliably parse trace / span IDs and include them in logs for correlation purposes.
-- Customers can use multiple tracing solutions (Zipkin + New Relic) at the same time and not have
- to worry about propagating two sets of context headers.
-- Frameworks can *bless* access to the trace context even if they prevent access to underlying
-request headers, making it available by default.
+See [Why is this needed?](https://github.com/w3c/distributed-tracing-wg/blob/main/EXPLAINER.md#why-is-this-needed)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,16 @@ Another system that supports the baggage concept is .NET. It supports it as part
 
 ## Why are we doing this
 
-See
-[Why](https://github.com/w3c/distributed-tracing-wg#why-are-we-doing-this)
+- If this becomes popular, frameworks and other services will automatically pass trace IDs
+through for correlated requests. This would prevent traces from hitting dead ends when a request
+reaches an un-instrumented service.
+- Once aligned on a header name, we can ask for a CORS exception from the W3C. This would allow
+browsers to attach trace IDs to requests and submit tracing data to a distributed tracing service.
+- Loggers can reliably parse trace / span IDs and include them in logs for correlation purposes.
+- Customers can use multiple tracing solutions (Zipkin + New Relic) at the same time and not have
+ to worry about propagating two sets of context headers.
+- Frameworks can *bless* access to the trace context even if they prevent access to underlying
+request headers, making it available by default.
 
 ## Contributing
 


### PR DESCRIPTION
Fixes #150

The "Why" link in `README.md` pointed to an external anchor (`#why-are-we-doing-this`) in the `w3c/distributed-tracing-wg` repository that no longer exists, resulting in a broken link for readers. Replaces the dead external link with the actual content inline in `README.md`, listing the five motivating reasons directly under the "Why are we doing this" section. Verified by inspecting the rendered markdown to confirm the section now displays complete, accessible content without any external link dependency.