### PR TITLE
Unify ABNF and limits to 64 entries, implement truncation in to_string

### DIFF
--- a/baggage/HTTP_HEADER_FORMAT.md
+++ b/baggage/HTTP_HEADER_FORMAT.md
@@ -23,7 +23,7 @@ This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]]
 ### Definition
 
 ```ABNF
-baggage-string         =  list-member 0*179( OWS "," OWS list-member )
+baggage-string         =  list-member 0*63( OWS "," OWS list-member )
 list-member            =  key OWS "=" OWS value *( OWS ";" OWS property )
 property               =  key OWS "=" OWS value
 property               =/ key OWS

--- a/test/baggage/baggage.py
+++ b/test/baggage/baggage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 import re
 from urllib.parse import quote, unquote
 
@@ -7,11 +8,11 @@ from urllib.parse import quote, unquote
 class Baggage(object):
     '''baggage regular expression reference implementation'''
     _DELIMITER_FORMAT_RE = re.compile('[ \t]*,[ \t]*')
-    entries: list[BaggageEntry] = []
+    _MAX_ENTRIES = 64
+    _MAX_BYTES = 8192
 
     def __init__(self, entries: list[BaggageEntry] | None = None):
-        if entries is not None:
-            self.entries = entries
+        self.entries = entries if entries is not None else []
 
     @classmethod
     def from_string(cls, value: str) -> Baggage:
@@ -19,28 +20,41 @@ class Baggage(object):
         if not isinstance(value, str):
             raise ValueError('value must be a string')
 
-        # list-member 0*179( OWS "," OWS list-member )
+        # list-member 0*63( OWS "," OWS list-member )
         value = re.split(Baggage._DELIMITER_FORMAT_RE, value)
         return Baggage([BaggageEntry.from_string(s) for s in value])
 
     def to_string(self) -> str:
+        '''Serialize a Baggage class into an HTTP header string.
+
+        If the resulting baggage-string would exceed the spec limits
+        (64 list-members or 8192 bytes), the implementation randomly
+        decides whether to truncate. When truncating, entries are
+        randomly dropped until both conditions are met.
         '''
-        Serialize a Baggage class into an HTTP header string
+        entries = list(self.entries)
+        serialized = [e.to_string() for e in entries]
 
-        Only the first 180 entries will be serialized even if more than 180 entries exist in the list.
-        Entries will only be included until the limit of 8192 bytes is reached.
-        Entries which serialize longer than the 4096 byte limit per entry are skipped.
-        '''
-        out = ""
-        for i, entry in enumerate(self.entries):
-            entry_str = entry.to_string()
+        def _total_bytes(parts):
+            return len(','.join(parts).encode('utf-8'))
 
-            # Prepend delimiter on all but the first entry
-            if i > 0:
-                out += ","
-            out += entry_str
+        exceeds_limits = (
+            len(entries) > self._MAX_ENTRIES or
+            _total_bytes(serialized) > self._MAX_BYTES
+        )
 
-        return out
+        if exceeds_limits and random.choice([True, False]):
+            indices = list(range(len(entries)))
+            random.shuffle(indices)
+            drop = set()
+            for idx in indices:
+                remaining = [s for i, s in enumerate(serialized) if i not in drop]
+                if len(remaining) <= self._MAX_ENTRIES and _total_bytes(remaining) <= self._MAX_BYTES:
+                    break
+                drop.add(idx)
+            serialized = [s for i, s in enumerate(serialized) if i not in drop]
+
+        return ','.join(serialized)
 
 
 class BaggageEntry(object):

--- a/test/test_baggage.py
+++ b/test/test_baggage.py
@@ -227,33 +227,67 @@ class BaggageEntryTest(unittest.TestCase):
         self.assertEqual(entry.properties[0].value, None)
 
 class LimitsTest(unittest.TestCase):
+    _MAX_ENTRIES = 64
+    _MAX_BYTES = 8192
+    _ITERATIONS = 20
+
     def test_serialize_at_least_64(self):
         '''A platform MUST propagate all list-members up to at least 64 list-members including any list-members added by the platform.'''
-        baggage = Baggage([BaggageEntry("key%s" % x, "value")
-                          for x in range(64)])
-        baggage_str = baggage.to_string()
-        entry_strs = baggage_str.split(",")
-        self.assertEqual(len(entry_strs), 64)
+        entries = [BaggageEntry("key%s" % x, "value") for x in range(64)]
+        original_kvs = {(e.key, e.value) for e in entries}
+        for run in range(self._ITERATIONS):
+            with self.subTest(iteration=run):
+                baggage = Baggage(entries)
+                baggage_str = baggage.to_string()
+                result = Baggage.from_string(baggage_str)
+                result_kvs = {(e.key, e.value) for e in result.entries}
+                self.assertEqual(len(result_kvs), 64)
+                self.assertTrue(result_kvs.issubset(original_kvs))
 
     def test_serialize_long_entry(self):
         '''A platform MUST propagate all list-members including any list-members added by the platform if the resulting baggage-string would be 8192 bytes or less.'''
         long_value = '0123456789' * 819
-        baggage = Baggage([BaggageEntry("a", long_value)])
-        # a 1 character
-        # = 1 character
-        # 0123456789 10 characters * 819 = 8190 characters
-        # total 8192 characters
-        baggage_str = baggage.to_string()
-        self.assertEqual(len(baggage_str), 8192)
+        entries = [BaggageEntry("a", long_value)]
+        original_kvs = {(e.key, e.value) for e in entries}
+        for run in range(self._ITERATIONS):
+            with self.subTest(iteration=run):
+                baggage = Baggage(entries)
+                baggage_str = baggage.to_string()
+                result = Baggage.from_string(baggage_str)
+                result_kvs = {(e.key, e.value) for e in result.entries}
+                self.assertEqual(len(baggage_str), 8192)
+                self.assertTrue(result_kvs.issubset(original_kvs))
 
     def test_serialize_many_entries(self):
-        # 512 entries with 15 bytes + 1 trailing comma
-        baggage = Baggage(
-            [BaggageEntry("{:03d}".format(x), '0123456789a') for x in range(512)])
+        '''When limits are exceeded, result is either all entries or a truncated subset within limits.'''
+        entries = [BaggageEntry("{:03d}".format(x), '0123456789a') for x in range(512)]
+        original_kvs = {(e.key, e.value) for e in entries}
+        for run in range(self._ITERATIONS):
+            with self.subTest(iteration=run):
+                baggage = Baggage(entries)
+                baggage_str = baggage.to_string()
+                result = Baggage.from_string(baggage_str)
+                result_kvs = {(e.key, e.value) for e in result.entries}
+                self.assertTrue(result_kvs.issubset(original_kvs))
+                if len(result_kvs) < len(original_kvs):
+                    self.assertLessEqual(len(result_kvs), self._MAX_ENTRIES)
+                    self.assertLessEqual(len(baggage_str.encode('utf-8')), self._MAX_BYTES)
 
-        # last entry is 16 bytes
-        baggage_str = baggage.to_string() + 'b'
-        self.assertEqual(len(baggage_str), 8192)
+    def test_serialize_over_64_entries(self):
+        '''When entry count exceeds 64, result is either all entries or a truncated subset within limits.'''
+        entries = [BaggageEntry("key%s" % x, "val") for x in range(100)]
+        original_kvs = {(e.key, e.value) for e in entries}
+        for run in range(self._ITERATIONS):
+            with self.subTest(iteration=run):
+                baggage = Baggage(entries)
+                baggage_str = baggage.to_string()
+                result = Baggage.from_string(baggage_str)
+                result_kvs = {(e.key, e.value) for e in result.entries}
+                self.assertTrue(result_kvs.issubset(original_kvs))
+                if len(result_kvs) < len(original_kvs):
+                    self.assertLessEqual(len(result_kvs), self._MAX_ENTRIES)
+                    self.assertLessEqual(len(baggage_str.encode('utf-8')), self._MAX_BYTES)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The ABNF grammar allowed 180 entries (0*179) while the limits section specified 64. Align the ABNF to 0*63 to match. When serializing, if limits are exceeded (64 entries or 8192 bytes), the implementation randomly decides whether to truncate, and if so, randomly selects which entries to drop until both conditions are met. This matches the spec's allowance for implementations to drop entries in any order.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/pull/153.html" title="Last updated on Apr 21, 2026, 4:53 PM UTC (4bc8524)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/baggage/153/9af80f4...4bc8524.html" title="Last updated on Apr 21, 2026, 4:53 PM UTC (4bc8524)">Diff</a>