### PR TITLE
Add implementations.md with OpenTelemetry baggage propagators

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -1,0 +1,17 @@
+# Implementations of Baggage
+
+This page contains an alphabetical list of projects and vendors that currently implement Baggage.
+
+## OpenTelemetry
+
+**Website:** [opentelemetry.io](https://opentelemetry.io)
+
+**Implementations:**
+| Implementations | Specification Level |
+| --------------- | :-----------------: |
+| [.NET](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs) | [CR](https://www.w3.org/TR/baggage/) |
+| [Go](https://github.com/open-telemetry/opentelemetry-go/blob/main/propagation/baggage.go) | [CR](https://www.w3.org/TR/baggage/) |
+| [Java](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/baggage/propagation/W3CBaggagePropagator.java) | [CR](https://www.w3.org/TR/baggage/) |
+| [JavaScript](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-core/src/baggage/propagation/W3CBaggagePropagator.ts) | [CR](https://www.w3.org/TR/baggage/) |
+| [Python](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-api/src/opentelemetry/baggage/propagation/__init__.py) | [CR](https://www.w3.org/TR/baggage/) |
+| [Ruby](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/api/lib/opentelemetry/baggage/propagation/text_map_propagator.rb) | [CR](https://www.w3.org/TR/baggage/) |


### PR DESCRIPTION
List OpenTelemetry implementations of the W3C Baggage specification across .NET, Go, Java, JavaScript, Python, and Ruby with links to the respective source files.